### PR TITLE
Fix line-height glitch on TextField's label

### DIFF
--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -75,7 +75,7 @@ export default class Label extends PureComponent {
         })
 
     let textStyle = {
-      lineHeight: fontSize,
+      lineHeight: (style && style.lineHeight) || fontSize,
       fontSize,
       color,
     }


### PR DESCRIPTION
Fix line-height glitch on TextField's label using custom fonts. Allows to specify custom `lineHeight` style prop to override the default (`fontSize`)

Fix for issue #19