### PR TITLE
Release/v1.0.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## [1.0.7](https://github.com/gabrieldonadel/rn-material-ui-textfield/compare/v1.0.6...v1.0.7) (2022-08-14)
+
+
+### Bug Fixes
+
+* Proptypes error on react-native 0.69 ([8b88da6](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/8b88da60cc1c027c56c0375be7c31e30b848baf5))
+
+
+### Features
+
+* Add typescript support to the project ([6b08613](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/6b0861358a7ed7b18a4dba8667b38ceba7c5147b))
+
+
+
 ## [1.0.6](https://github.com/gabrieldonadel/rn-material-ui-textfield/compare/v1.0.4...v1.0.6) (2022-03-04)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-material-ui-textfield",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Material UI textfield",
   "keywords": [
     "react",


### PR DESCRIPTION
### Bug Fixes

* Proptypes error on react-native 0.69 ([8b88da6](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/8b88da6))


### Features

* Add typescript support to the project ([6b08613](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/6b08613))



