### PR TITLE
Fixing the issue regarding labels and usage within browsers

### DIFF
--- a/src/components/label/styles.native.js
+++ b/src/components/label/styles.native.js
@@ -4,9 +4,9 @@ export default StyleSheet.create({
   container: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    maxWidth: '133%',
-    transformOrigin: 'top left',
+    left: '-100%',
+    width: '200%',
+    paddingLeft: '50%',
   },
 
   text: {


### PR DESCRIPTION
## Description

See ticket #65 

## How has this been tested?
I have tested in Edge, Safari and firefox. 

## Screenshots
<img width="270" alt="image" src="https://user-images.githubusercontent.com/2812277/198988141-abf97296-422e-428e-bc05-888b793bd0ca.png">
<img width="386" alt="image" src="https://user-images.githubusercontent.com/2812277/198988165-7c158fb3-ee21-4339-befa-9831e57090c1.png">
