### PR TITLE
Release/v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![npm][npm-badge]][npm-url] [![npm downloads][npm-downloads-badge]][npm-url] [![license][license-badge]][license-url]
 
-Material UI texfield with consistent behaviour on iOS and Android
+Material UI texfield with consistent behaviour on Android, iOS and Web
 
 ![example][example-url]
 
@@ -42,21 +42,25 @@ npm install rn-material-ui-textfield
 ## Usage
 
 ```javascript
-import React, { Component } from 'react'
-import { TextField, FilledTextField, OutlinedTextField } from 'rn-material-ui-textfield'
+import React, { Component } from 'react';
+import {
+  TextField,
+  FilledTextField,
+  OutlinedTextField,
+} from 'rn-material-ui-textfield';
 
 class Example extends Component {
-  fieldRef = React.createRef()
+  fieldRef = React.createRef();
 
   onSubmit = () => {
-    let { current: field } = this.fieldRef
+    let { current: field } = this.fieldRef;
 
-    console.log(field.value())
-  }
+    console.log(field.value());
+  };
 
   formatText = (text) => {
-    return text.replace(/[^+\d]/g, '')
-  }
+    return text.replace(/[^+\d]/g, '');
+  };
 
   render() {
     return (
@@ -67,7 +71,7 @@ class Example extends Component {
         onSubmitEditing={this.onSubmit}
         ref={this.fieldRef}
       />
-    )
+    );
   }
 }
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+## [1.0.9](https://github.com/gabrieldonadel/rn-material-ui-textfield/compare/v1.0.8...v1.0.9) (2022-11-03)
+
+
+### Features
+
+* Add expo example app with web support ([2bb2cf2](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/2bb2cf221de716d3f08f12ad6de45c560425a1b1))
+
+### Bug Fixes
+
+* Fix `labels` styles for web ([97a03cb](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/97a03cb))
+
+
 ## [1.0.8](https://github.com/gabrieldonadel/rn-material-ui-textfield/compare/v1.0.7...v1.0.8) (2022-10-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-material-ui-textfield",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Material UI textfield",
   "keywords": [
     "react",


### PR DESCRIPTION
### Features

* Add expo example app with web support ([2bb2cf2](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/2bb2cf221de716d3f08f12ad6de45c560425a1b1))

### Bug Fixes

* Fix `labels` styles for web ([97a03cb](https://github.com/gabrieldonadel/rn-material-ui-textfield/commit/97a03cb))